### PR TITLE
Fixes to make it work with AKS 1.29 version

### DIFF
--- a/configuration/iaac/aws/kubernetes/final-main.txt
+++ b/configuration/iaac/aws/kubernetes/final-main.txt
@@ -17,60 +17,71 @@ resource "aws_default_vpc" "default" {
 
 }
 
-data "aws_subnet_ids" "subnets" {
-  vpc_id = aws_default_vpc.default.id
+# data "aws_subnet_ids" "subnets" {
+#  vpc_id = aws_default_vpc.default.id
+# }
+
+data "aws_eks_cluster" "example" {
+   name = "in28minutes-cluster"
+ }
+
+data "aws_eks_cluster_auth" "example" {
+  name = "in28minutes-cluster"
 }
 
-
+#Get token to connect to Kubernetes
 provider "kubernetes" {
-  //>>Uncomment this section once EKS is created - Start
-  host                   = data.aws_eks_cluster.cluster.endpoint #module.in28minutes-cluster.cluster_endpoint
-  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
-  token                  = data.aws_eks_cluster_auth.cluster.token
-  //>>Uncomment this section once EKS is created - End
+  host                   = data.aws_eks_cluster.example.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.example.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.example.token
 }
+
 
 module "in28minutes-cluster" {
-  source          = "terraform-aws-modules/eks/aws"
+  source  = "terraform-aws-modules/eks/aws"
+  version = "19.15.3"
+
   cluster_name    = "in28minutes-cluster"
-  cluster_version = "1.23"
+  cluster_version = "1.29"
+
   subnet_ids         = ["subnet-0ba16627", "subnet-02db6b4a", "subnet-e08479ba"] #CHANGE # Donot choose subnet from us-east-1e
+  #subnets = data.aws_subnet_ids.subnets.ids
   vpc_id          = aws_default_vpc.default.id
+  #vpc_id         = "vpc-1234556abcdef"
 
   //Newly added entry to allow connection to the api server
   //Without this change error in step 163 in course will not go away
   cluster_endpoint_public_access  = true
 
-# EKS Managed Node Group(s)
   eks_managed_node_group_defaults = {
-    instance_types = ["t2.small", "t2.medium"]
+    ami_type = "AL2_x86_64"
+
   }
 
   eks_managed_node_groups = {
-    blue = {}
-    green = {
-      min_size     = 1
-      max_size     = 10
-      desired_size = 1
+    one = {
+      name = "node-group-1"
 
-      instance_types = ["t2.medium"]
+      instance_types = ["t3.small"]
+
+      min_size     = 1
+      max_size     = 3
+      desired_size = 2
+    }
+
+    two = {
+      name = "node-group-2"
+
+      instance_types = ["t3.small"]
+
+      min_size     = 1
+      max_size     = 2
+      desired_size = 1
     }
   }
+
 }
 
-//>>Uncomment this section once EKS is created - Start
- data "aws_eks_cluster" "cluster" {
-   name = "in28minutes-cluster" #module.in28minutes-cluster.cluster_name
- }
-
-data "aws_eks_cluster_auth" "cluster" {
-  name = "in28minutes-cluster" #module.in28minutes-cluster.cluster_name
-}
-
-
-# We will use ServiceAccount to connect to K8S Cluster in CI/CD mode
-# ServiceAccount needs permissions to create deployments 
-# and services in default namespace
 resource "kubernetes_cluster_role_binding" "example" {
   metadata {
     name = "fabric8-rbac"
@@ -86,7 +97,20 @@ resource "kubernetes_cluster_role_binding" "example" {
     namespace = "default"
   }
 }
-//>>Uncomment this section once EKS is created - End
+
+# Create a secret. After version 1.23 there is no default secret
+resource "kubernetes_secret" "example" {
+  metadata {
+    annotations = {
+      "kubernetes.io/service-account.name" = "default"
+    }
+
+    generate_name = "terraform-default-"
+  }
+
+  type                           = "kubernetes.io/service-account-token"
+  wait_for_service_account_token = true
+}
 
 # Needed to set the default region
 provider "aws" {

--- a/configuration/iaac/aws/kubernetes/final-main.txt
+++ b/configuration/iaac/aws/kubernetes/final-main.txt
@@ -17,10 +17,6 @@ resource "aws_default_vpc" "default" {
 
 }
 
-# data "aws_subnet_ids" "subnets" {
-#  vpc_id = aws_default_vpc.default.id
-# }
-
 data "aws_eks_cluster" "example" {
    name = "in28minutes-cluster"
  }

--- a/configuration/iaac/aws/kubernetes/main.tf
+++ b/configuration/iaac/aws/kubernetes/main.tf
@@ -17,76 +17,103 @@ resource "aws_default_vpc" "default" {
 
 }
 
-data "aws_subnet_ids" "subnets" {
-  vpc_id = aws_default_vpc.default.id
-}
+# data "aws_subnet_ids" "subnets" {
+#  vpc_id = aws_default_vpc.default.id
+# }
 
+### Uncomment this section after cluster creation line numbers 25 to 31 ###
+#data "aws_eks_cluster" "example" {
+#   name = "in28minutes-cluster"
+# }
+
+#data "aws_eks_cluster_auth" "example" {
+#  name = "in28minutes-cluster"
+#}
+### Uncomment this section after cluster creation ###
 
 provider "kubernetes" {
-  //>>Uncomment this section once EKS is created - Start
-  # host                   = data.aws_eks_cluster.cluster.endpoint #module.in28minutes-cluster.cluster_endpoint
-  # cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
-  # token                  = data.aws_eks_cluster_auth.cluster.token
-  //>>Uncomment this section once EKS is created - End
+### Uncomment this section after cluster creation line numbers 36 to 38###
+#  host                   = data.aws_eks_cluster.example.endpoint
+#  cluster_ca_certificate = base64decode(data.aws_eks_cluster.example.certificate_authority[0].data)
+#  token                  = data.aws_eks_cluster_auth.example.token
+### Uncomment this section after cluster creation ###
 }
 
+
 module "in28minutes-cluster" {
-  source          = "terraform-aws-modules/eks/aws"
+  source  = "terraform-aws-modules/eks/aws"
+  version = "19.15.3"
+
   cluster_name    = "in28minutes-cluster"
-  cluster_version = "1.23"
+  cluster_version = "1.29"
+
   subnet_ids         = ["subnet-0ba16627", "subnet-02db6b4a", "subnet-e08479ba"] #CHANGE # Donot choose subnet from us-east-1e
+  #subnets = data.aws_subnet_ids.subnets.ids
   vpc_id          = aws_default_vpc.default.id
+  #vpc_id         = "vpc-1234556abcdef"
 
   //Newly added entry to allow connection to the api server
   //Without this change error in step 163 in course will not go away
   cluster_endpoint_public_access  = true
 
-# EKS Managed Node Group(s)
   eks_managed_node_group_defaults = {
-    instance_types = ["t2.small", "t2.medium"]
+    ami_type = "AL2_x86_64"
+
   }
 
   eks_managed_node_groups = {
-    blue = {}
-    green = {
-      min_size     = 1
-      max_size     = 10
-      desired_size = 1
+    one = {
+      name = "node-group-1"
 
-      instance_types = ["t2.medium"]
+      instance_types = ["t3.small"]
+
+      min_size     = 1
+      max_size     = 3
+      desired_size = 2
+    }
+
+    two = {
+      name = "node-group-2"
+
+      instance_types = ["t3.small"]
+
+      min_size     = 1
+      max_size     = 2
+      desired_size = 1
     }
   }
+
 }
-
-//>>Uncomment this section once EKS is created - Start
-#  data "aws_eks_cluster" "cluster" {
-#    name = "in28minutes-cluster" #module.in28minutes-cluster.cluster_name
+### Uncomment this section after cluster creation line numbers 88 to 115###
+#resource "kubernetes_cluster_role_binding" "example" {
+#  metadata {
+#    name = "fabric8-rbac"
 #  }
-
-# data "aws_eks_cluster_auth" "cluster" {
-#   name = "in28minutes-cluster" #module.in28minutes-cluster.cluster_name
+#  role_ref {
+#    api_group = "rbac.authorization.k8s.io"
+#    kind      = "ClusterRole"
+#    name      = "cluster-admin"
+#  }
+#  subject {
+#    kind      = "ServiceAccount"
+#    name      = "default"
+#    namespace = "default"
+#  }
 # }
 
-
-# # We will use ServiceAccount to connect to K8S Cluster in CI/CD mode
-# # ServiceAccount needs permissions to create deployments 
-# # and services in default namespace
-# resource "kubernetes_cluster_role_binding" "example" {
-#   metadata {
-#     name = "fabric8-rbac"
-#   }
-#   role_ref {
-#     api_group = "rbac.authorization.k8s.io"
-#     kind      = "ClusterRole"
-#     name      = "cluster-admin"
-#   }
-#   subject {
-#     kind      = "ServiceAccount"
-#     name      = "default"
-#     namespace = "default"
-#   }
+#resource "kubernetes_secret" "example" {
+#  metadata {
+#    annotations = {
+#      "kubernetes.io/service-account.name" = "default"
+#    }
+#
+#    generate_name = "terraform-default-"
+#  }
+#
+#  type                           = "kubernetes.io/service-account-token"
+#  wait_for_service_account_token = true
 # }
-//>>Uncomment this section once EKS is created - End
+### Uncomment this section after cluster creation ###
 
 # Needed to set the default region
 provider "aws" {

--- a/configuration/iaac/aws/kubernetes/main.tf
+++ b/configuration/iaac/aws/kubernetes/main.tf
@@ -17,10 +17,6 @@ resource "aws_default_vpc" "default" {
 
 }
 
-# data "aws_subnet_ids" "subnets" {
-#  vpc_id = aws_default_vpc.default.id
-# }
-
 ### Uncomment this section after cluster creation line numbers 25 to 31 ###
 #data "aws_eks_cluster" "example" {
 #   name = "in28minutes-cluster"


### PR DESCRIPTION
The terraform creation starting to fail. Needs to be upgraded to AKS 1.29 version as old versions are set to be removed from support.